### PR TITLE
認証メールの設定変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,16 +63,18 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "movie_chat_#{Rails.env}"
 
-  config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { :host => 'https://movies-chat.herokuapp.com/' }
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    :user_name => ENV['SENDGRID_USERNAME'],
-    :password => ENV['SENDGRID_PASSWORD'],
-    :domain => "heroku.com",
-    :address => "smtp.sendgrid.net",
-    :port => 587,
+  host = "#{ENV['HEROKU_APPNAME']}.herokuapp.com"
+  config.action_mailer.default_url_options = { host: host, protocol: 'https' }
+  ActionMailer::Base.smtp_settings = {
+    :address        => 'smtp.gmail.com',
+    :port           => '587',
     :authentication => :plain,
+    :user_name      => ENV['GMAIL_USERNAME'],
+    :password       => ENV['GMAIL_PASSWORD'],
+    :domain         => 'gmail.com',
     :enable_starttls_auto => true
   }
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
   config.mailer_sender = ENV["MAIL_USERNAME"]
-
+  config.mailer_sender = ENV["GMAIL_USERNAME"]
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 


### PR DESCRIPTION
# 何か
- 新規登録時の認証メール送信の設定（Gmailへ変更）
→ 送信元のアドレスをgmailのアドレスに環境変数で設定